### PR TITLE
use snippet from .snippet file

### DIFF
--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -7,8 +7,29 @@ module SnippetBuilder
   module_function
 
   def build
-    [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
-      .map { |snippet| '# ' + snippet }
-      .join("\n") + "\n"
+    create_snippet_file unless File.exist?('.snippet')
+    read_snippet_file
   end
+
+  def create_snippet_file
+    file = File.open('.snippet', 'w')
+    constants
+      .map { |snippet| file.puts('# ' + eval(snippet.to_s)) }
+    file.close
+
+    # \e[32m green color
+    puts "    \e[32mcreate\e[0m #{FileUtils.pwd}/.snippet"
+
+    File.exist?('.snippet') ? true : false
+  end
+
+  def read_snippet_file
+    file = File.open('.snippet', 'r')
+    snippet = file.read || ''
+    file.close
+
+    snippet
+  end
+
+  private_class_method :create_snippet_file, :read_snippet_file
 end

--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -13,8 +13,8 @@ module SnippetBuilder
 
   def create_snippet_file
     file = File.open('.snippet', 'w')
-    constants
-      .map { |snippet| file.puts('# ' + eval(snippet.to_s)) }
+    [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
+      .map { |snippet| file.puts("# #{snippet}") }
     file.close
 
     # \e[32m green color

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 RSpec.describe GreenDay::Cli do
   let!(:cli) { described_class.new }
 
+  RSpec.configure do |config|
+    config.after(:suite) do
+      FileUtils.remove_entry_secure('.snippet')
+    end
+  end
+
   describe 'new [contest name]' do
     # https://atcoder.jp/contests/abc150
     subject { cli.new('abc150') }


### PR DESCRIPTION
fix #13 

# What
.snippetファイルを読み取ってスニペットにする仕様に変更した。
green_day newコマンド実行時、.snippetファイルがなければ生成するようにした。

# Why
ユーザが任意のスニペットを定義できるようにするため

# Tasks

- [x] 実装
- [x] テストグリーン
- [ ] versionの変更
- [x] Sider通過
- [ ] CIグリーン
