### PR TITLE
Green day rspec cmd

### DIFF
--- a/lib/green_day/cli.rb
+++ b/lib/green_day/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'thor'
+require 'rspec'
 require_relative 'atcoder_client'
 require_relative 'contest'
 require_relative 'test_builder'
@@ -29,6 +30,12 @@ module GreenDay
         create_submit_file!(contest_name, task_code)
         create_spec_file!(contest_name, task_code, task.input_output_hash)
       end
+    end
+
+    desc 'rspec [contest name] [task code]', 'exec rspec with contest test case'
+    def rspec(contest_name, task_code)
+      file_path = spec_file_path(contest_name.downcase, task_code.upcase)
+      RSpec::Core::Runner.run([file_path])
     end
 
     private

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -110,4 +110,29 @@ RSpec.describe GreenDay::Cli do
       end
     end
   end
+
+  describe 'rspec [contest name] [task code]' do
+    subject { cli.rspec('abc150', 'A') }
+    before do
+      allow(RSpec::Core::Runner).to receive(:run)
+    end
+
+    it 'exec rspec command' do
+      subject
+      expect(RSpec::Core::Runner).to \
+        have_received(:run).with(['abc150/spec/A_spec.rb']).once
+    end
+
+    it 'replace the contest name with lowercase' do
+      cli.rspec('ABC150', 'A')
+      expect(RSpec::Core::Runner).to \
+        have_received(:run).with(['abc150/spec/A_spec.rb']).once
+    end
+
+    it 'replace the task code with uppercase' do
+      cli.rspec('abc150', 'a')
+      expect(RSpec::Core::Runner).to \
+        have_received(:run).with(['abc150/spec/A_spec.rb']).once
+    end
+  end
 end


### PR DESCRIPTION
fix #17 

# What
green_dayにrspecコマンドを実装した。
## Usage

`green_day rspec [contest name] [task code]`

## example
`green_day rspec abc000 A`

# Why
atcoderの一連の作業をgreen_dayコマンドで実行できるようにするため

# Tasks

- [x] 実装
- [x] テストグリーン
- [ ] versionの変更
- [x] Sider通過
- [ ] CIグリーン
