### PR TITLE
use path attributes in task for various forms of task path

### DIFF
--- a/lib/green_day/cli.rb
+++ b/lib/green_day/cli.rb
@@ -53,11 +53,11 @@ module GreenDay
     end
 
     def submit_file_path(task)
-      "#{task.contest.name}/#{task.code}.rb"
+      "#{task.contest.name}/#{task.name}.rb"
     end
 
     def spec_file_path(task)
-      "#{task.contest.name}/spec/#{task.code}_spec.rb"
+      "#{task.contest.name}/spec/#{task.name}_spec.rb"
     end
   end
 end

--- a/lib/green_day/task.rb
+++ b/lib/green_day/task.rb
@@ -1,22 +1,37 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module GreenDay
   class Task
-    attr_reader :contest, :code, :sample_answers
+    extend Forwardable
+    delegate get_parsed_body: :@client
 
-    def initialize(contest, code, client)
+    attr_reader :contest, :name, :path, :sample_answers
+
+    def initialize(contest, name, path, client)
+      @client = client
       @contest = contest
-      @code = code
-      @sample_answers = create_sample_answers(client)
+      @name = name
+      @path = path
+      @sample_answers = create_sample_answers_hash
     end
 
     private
 
-    def create_sample_answers(client)
-      input_samples, output_samples =
-        client.fetch_inputs_and_outputs(contest, self)
+    def create_sample_answers_hash
+      input_samples, output_samples = fetch_inputs_and_outputs
 
       input_samples.zip(output_samples).to_h
+    end
+
+    def fetch_inputs_and_outputs
+      body = get_parsed_body(path)
+      samples = body.css('.lang-ja > .part > section > pre').map { |e| e.children.text }
+
+      inputs, outputs = samples.partition.with_index { |_sample, i| i.even? }
+
+      [inputs, outputs]
     end
   end
 end

--- a/spec/green_day/cli_spec.rb
+++ b/spec/green_day/cli_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe GreenDay::Cli, vcr: true do
       # https://atcoder.jp/contests/math-and-algorithm
       let(:contest_name) { 'math-and-algorithm' }
 
-      it "task url is correct" do
+      it 'task url is correct' do
         expect(File.read('math-and-algorithm/spec/001_spec.rb')).to match(/expect/)
       end
     end


### PR DESCRIPTION
contest内のタスクnameの変換形式が統一されていないようなので、直接タスクのpathをコンテストのHTMLから取り出すロジックにした
ref #43 