### PR TITLE
By using the environment variable GD_REPL, you can now start repl after passing sample input to the submission file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,33 +50,67 @@ For example
    ```
    
    Example of output spec
-   
-   ```ruby
-  RSpec.describe 'test' do
-    it 'test with "2 900\\n"' do
-      io = IO.popen("ruby abc150/A.rb", "w+")
-      io.puts("2 900\\n")
-      io.close_write
-      expect(io.readlines.join).to eq("Yes\\n")
-    end
 
-    it 'test with "1 501\\n"' do
-      io = IO.popen("ruby abc150/A.rb", "w+")
-      io.puts("1 501\\n")
+```ruby
+RSpec.describe 'abc150/A.rb' do
+  it 'test with "2 900\n"' do
+    if ENV['GD_REPL']
+      File.chmod(0o755, 'abc150/A.rb')
+      system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "2 900\n\\004"; interact'))
+    else
+      io = IO.popen('ruby abc150/A.rb', 'w+')
+      io.puts("2 900\n")
       io.close_write
-      expect(io.readlines.join).to eq("No\\n")
+      expect(io.readlines.join).to eq("Yes\n")
     end
-
-    it 'test with "4 2000\\n"' do
-      io = IO.popen("ruby abc150/A.rb", "w+")
-      io.puts("4 2000\\n")
-      io.close_write
-      expect(io.readlines.join).to eq("Yes\\n")
-    end
-
   end
-  ```
 
+  it 'test with "1 501\n"' do
+    if ENV['GD_REPL']
+      File.chmod(0o755, 'abc150/A.rb')
+      system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "1 501\n\\004"; interact'))
+    else
+      io = IO.popen('ruby abc150/A.rb', 'w+')
+      io.puts("1 501\n")
+      io.close_write
+      expect(io.readlines.join).to eq("No\n")
+    end
+  end
+
+  it 'test with "4 2000\n"' do
+    if ENV['GD_REPL']
+      File.chmod(0o755, 'abc150/A.rb')
+      system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "4 2000\n\\004"; interact'))
+    else
+      io = IO.popen('ruby abc150/A.rb', 'w+')
+      io.puts("4 2000\n")
+      io.close_write
+      expect(io.readlines.join).to eq("Yes\n")
+    end
+  end
+
+end
+
+```
+## Debugging with REPL
+You can debug your code with sample input and REPL by setting `GD_REPL` environment variable.
+
+```
+$ GD_REPL=1 bundle exec rspec abc150/spec/A_spec.rb
+
+abc150/A.rb
+spawn ruby abc150/A.rb
+2 900
+
+From: abc150/A.rb @ line 2 :
+
+    1: a, b = gets.split.map(&:to_i)
+ => 2: binding.irb
+    3: puts "Yes"
+
+irb(main):001:0> a
+=> 2
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/green_day/test_builder.rb
+++ b/lib/green_day/test_builder.rb
@@ -6,22 +6,29 @@ module GreenDay
 
     def build_test(submit_file_path, input_output_hash)
       <<~SPEC
-        RSpec.describe 'test' do
+        RSpec.describe '#{submit_file_path}' do
         #{input_output_hash.map { |input, output| build_example(submit_file_path, input, output) }.join("\n")}
         end
       SPEC
     end
 
+    # rubocop:disable Metrics/AbcSize
     def build_example(submit_file_path, input, output)
       <<~SPEC
-        #{tab}it 'test with #{unify_cr_lf(input)}' do
-        #{tab}#{tab}io = IO.popen("ruby #{submit_file_path}", "w+")
-        #{tab}#{tab}io.puts(#{unify_cr_lf(input)})
-        #{tab}#{tab}io.close_write
-        #{tab}#{tab}expect(io.readlines.join).to eq(#{unify_cr_lf(output)})
+        #{tab}it 'test with #{unify_cr_lf(input).chomp}' do
+        #{tab}#{tab}if ENV['GD_REPL']
+        #{tab}#{tab}#{tab}File.chmod(0o755, '#{submit_file_path}')
+        #{tab}#{tab}#{tab}system(%q(expect -c 'set timeout 2; spawn ruby #{submit_file_path}; send #{unify_cr_lf("#{input}\\004")}; interact'))
+        #{tab}#{tab}else
+        #{tab}#{tab}#{tab}io = IO.popen('ruby #{submit_file_path}', 'w+')
+        #{tab}#{tab}#{tab}io.puts(#{unify_cr_lf(input)})
+        #{tab}#{tab}#{tab}io.close_write
+        #{tab}#{tab}#{tab}expect(io.readlines.join).to eq(#{unify_cr_lf(output)})
+        #{tab}#{tab}end
         #{tab}end
       SPEC
     end
+    # rubocop:enable Metrics/AbcSize
 
     def unify_cr_lf(string)
       return unless string # たまに画像で例を出してくるとsampleの文字がなくなる

--- a/spec/green_day/cli_spec.rb
+++ b/spec/green_day/cli_spec.rb
@@ -44,26 +44,41 @@ RSpec.describe GreenDay::Cli, :vcr do
     it 'writes spec code' do
       expect(File.read('abc150/spec/A_spec.rb')).to eq(
         <<~SPEC
-          RSpec.describe 'test' do
+          RSpec.describe 'abc150/A.rb' do
             it 'test with "2 900\\n"' do
-              io = IO.popen("ruby abc150/A.rb", "w+")
-              io.puts("2 900\\n")
-              io.close_write
-              expect(io.readlines.join).to eq("Yes\\n")
+              if ENV['GD_REPL']
+                File.chmod(0o755, 'abc150/A.rb')
+                system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "2 900\\n\\\\004"; interact'))
+              else
+                io = IO.popen('ruby abc150/A.rb', 'w+')
+                io.puts("2 900\\n")
+                io.close_write
+                expect(io.readlines.join).to eq("Yes\\n")
+              end
             end
 
             it 'test with "1 501\\n"' do
-              io = IO.popen("ruby abc150/A.rb", "w+")
-              io.puts("1 501\\n")
-              io.close_write
-              expect(io.readlines.join).to eq("No\\n")
+              if ENV['GD_REPL']
+                File.chmod(0o755, 'abc150/A.rb')
+                system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "1 501\\n\\\\004"; interact'))
+              else
+                io = IO.popen('ruby abc150/A.rb', 'w+')
+                io.puts("1 501\\n")
+                io.close_write
+                expect(io.readlines.join).to eq("No\\n")
+              end
             end
 
             it 'test with "4 2000\\n"' do
-              io = IO.popen("ruby abc150/A.rb", "w+")
-              io.puts("4 2000\\n")
-              io.close_write
-              expect(io.readlines.join).to eq("Yes\\n")
+              if ENV['GD_REPL']
+                File.chmod(0o755, 'abc150/A.rb')
+                system(%q(expect -c 'set timeout 2; spawn ruby abc150/A.rb; send "4 2000\\n\\\\004"; interact'))
+              else
+                io = IO.popen('ruby abc150/A.rb', 'w+')
+                io.puts("4 2000\\n")
+                io.close_write
+                expect(io.readlines.join).to eq("Yes\\n")
+              end
             end
 
           end

--- a/spec/green_day/test_builder_spec.rb
+++ b/spec/green_day/test_builder_spec.rb
@@ -15,10 +15,15 @@ RSpec.describe GreenDay::TestBuilder do
       expect(subject).to eq(
         <<~SPEC
           \s\sit 'test with "2 900\\n"' do
-          \s\s\s\sio = IO.popen("ruby submit_file", "w+")
-          \s\s\s\sio.puts("2 900\\n")
-          \s\s\s\sio.close_write
-          \s\s\s\sexpect(io.readlines.join).to eq("Yes\\n")
+          \s\s\s\sif ENV['GD_REPL']
+          \s\s\s\s\s\sFile.chmod(0o755, 'submit_file')
+          \s\s\s\s\s\ssystem(%q(expect -c 'set timeout 2; spawn ruby submit_file; send "2 900\\n\\\\004"; interact'))
+          \s\s\s\selse
+          \s\s\s\s\s\sio = IO.popen('ruby submit_file', 'w+')
+          \s\s\s\s\s\sio.puts("2 900\\n")
+          \s\s\s\s\s\sio.close_write
+          \s\s\s\s\s\sexpect(io.readlines.join).to eq("Yes\\n")
+          \s\s\s\send
           \s\send
         SPEC
       )
@@ -33,19 +38,29 @@ RSpec.describe GreenDay::TestBuilder do
     it {
       expect(subject).to eq(
         <<~SPEC
-          RSpec.describe 'test' do
+          RSpec.describe 'submit_file' do
           \s\sit 'test with "2 900\\n"' do
-          \s\s\s\sio = IO.popen("ruby submit_file", "w+")
-          \s\s\s\sio.puts("2 900\\n")
-          \s\s\s\sio.close_write
-          \s\s\s\sexpect(io.readlines.join).to eq("Yes\\n")
+          \s\s\s\sif ENV['GD_REPL']
+          \s\s\s\s\s\sFile.chmod(0o755, 'submit_file')
+          \s\s\s\s\s\ssystem(%q(expect -c 'set timeout 2; spawn ruby submit_file; send "2 900\\n\\\\004"; interact'))
+          \s\s\s\selse
+          \s\s\s\s\s\sio = IO.popen('ruby submit_file', 'w+')
+          \s\s\s\s\s\sio.puts("2 900\\n")
+          \s\s\s\s\s\sio.close_write
+          \s\s\s\s\s\sexpect(io.readlines.join).to eq("Yes\\n")
+          \s\s\s\send
           \s\send
 
           \s\sit 'test with "3 900\\n"' do
-          \s\s\s\sio = IO.popen("ruby submit_file", "w+")
-          \s\s\s\sio.puts("3 900\\n")
-          \s\s\s\sio.close_write
-          \s\s\s\sexpect(io.readlines.join).to eq("No\\n")
+          \s\s\s\sif ENV['GD_REPL']
+          \s\s\s\s\s\sFile.chmod(0o755, 'submit_file')
+          \s\s\s\s\s\ssystem(%q(expect -c 'set timeout 2; spawn ruby submit_file; send "3 900\\n\\\\004"; interact'))
+          \s\s\s\selse
+          \s\s\s\s\s\sio = IO.popen('ruby submit_file', 'w+')
+          \s\s\s\s\s\sio.puts("3 900\\n")
+          \s\s\s\s\s\sio.close_write
+          \s\s\s\s\s\sexpect(io.readlines.join).to eq("No\\n")
+          \s\s\s\send
           \s\send
 
           end


### PR DESCRIPTION
fix #32 